### PR TITLE
feat: add slider for target year selection in MetricCard

### DIFF
--- a/cdn/client/metadata.mjs
+++ b/cdn/client/metadata.mjs
@@ -179,6 +179,14 @@ export const localication = {
     en,
 };
 
+export const BandColor = {
+    YELLOW: 'YELLOW',
+    LIGHT_GREEN: 'LIGHT_GREEN',
+    GREEN: 'GREEN',
+    LIGHT_RED: 'LIGHT_RED',
+    RED: 'RED',
+};
+
 export const pointGroup = {
     METADATA: 'metadata',
     PHYSICAL: 'physical',
@@ -278,8 +286,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['RED', 'LIGHT_RED', 'YELLOW', 'LIGHT_GREEN', 'GREEN']
-      }
+        global: [BandColor.RED, BandColor.LIGHT_RED, BandColor.YELLOW, BandColor.LIGHT_GREEN, BandColor.GREEN]
+      },
+      isInteger: false
     }
   },
   SMK_RISK_PROB: {
@@ -351,8 +360,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: true
     }
   },
   SLEEP_QUALITY: {
@@ -434,8 +444,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['RED', 'LIGHT_RED', 'YELLOW', 'LIGHT_GREEN', 'GREEN']
-      }
+        global: [BandColor.RED, BandColor.LIGHT_RED, BandColor.YELLOW, BandColor.LIGHT_GREEN, BandColor.GREEN]
+      },
+      isInteger: false
     }
   },
   ANXIETY_INDEX: {
@@ -517,8 +528,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: false
     }
   },
   SNR: {
@@ -539,7 +551,8 @@ export const DFX_POINTS = {
       },
       dialBandColors: {
         global: []
-      }
+      },
+      isInteger: false
     }
   },
   HR_BPM: {
@@ -617,8 +630,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['YELLOW', 'GREEN', 'YELLOW']
-      }
+        global: [BandColor.YELLOW, BandColor.GREEN, BandColor.YELLOW]
+      },
+      isInteger: true
     }
   },
   BP_SYSTOLIC: {
@@ -700,8 +714,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['YELLOW', 'GREEN', 'LIGHT_GREEN', 'YELLOW', 'RED']
-      }
+        global: [BandColor.YELLOW, BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.RED]
+      },
+      isInteger: true
     }
   },
   BP_DIASTOLIC: {
@@ -783,8 +798,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['YELLOW', 'GREEN', 'LIGHT_GREEN', 'YELLOW', 'RED']
-      }
+        global: [BandColor.YELLOW, BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.RED]
+      },
+      isInteger: true
     }
   },
   BR_BPM: {
@@ -862,8 +878,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['YELLOW', 'GREEN', 'YELLOW']
-      }
+        global: [BandColor.YELLOW, BandColor.GREEN, BandColor.YELLOW]
+      },
+      isInteger: true
     }
   },
   HRV_SDNN: {
@@ -945,8 +962,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['RED', 'LIGHT_RED', 'YELLOW', 'LIGHT_GREEN', 'GREEN']
-      }
+        global: [BandColor.RED, BandColor.LIGHT_RED, BandColor.YELLOW, BandColor.LIGHT_GREEN, BandColor.GREEN]
+      },
+      isInteger: true
     }
   },
   ABSI: {
@@ -1217,11 +1235,12 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        globalMale: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED'],
-        globalFemale: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED'],
-        eastAsiaMale: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED'],
-        eastAsiaFemale: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        globalMale: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED],
+        globalFemale: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED],
+        eastAsiaMale: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED],
+        eastAsiaFemale: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: false
     }
   },
   BMI_CALC: {
@@ -1405,10 +1424,11 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: [ 'YELLOW', 'GREEN', 'YELLOW', 'LIGHT_RED', 'RED' ],
-        eastAsiaMale: [ 'YELLOW', 'GREEN', 'YELLOW', 'RED' ],
-        eastAsiaFemale: [ 'YELLOW', 'GREEN', 'YELLOW', 'RED' ]
-      }
+        global: [ BandColor.YELLOW, BandColor.GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED ],
+        eastAsiaMale: [ BandColor.YELLOW, BandColor.GREEN, BandColor.YELLOW, BandColor.RED ],
+        eastAsiaFemale: [ BandColor.YELLOW, BandColor.GREEN, BandColor.YELLOW, BandColor.RED ]
+      },
+      isInteger: true
     }
   },
   BP_RPP: {
@@ -1490,8 +1510,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: false
     }
   },
   BP_CVD: {
@@ -1573,8 +1594,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: true
     }
   },
   CVD_MULTI_YEAR_RISK_YEARS: {
@@ -1595,7 +1617,8 @@ export const DFX_POINTS = {
       },
       dialBandColors: {
         global: []
-      }
+      },
+      isInteger: false
     }
   },
   CVD_MULTI_YEAR_RISK_PROBS: {
@@ -1677,8 +1700,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: true
     }
   },
   HEALTH_SCORE: {
@@ -1760,8 +1784,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['RED', 'LIGHT_RED', 'YELLOW', 'LIGHT_GREEN', 'GREEN']
-      }
+        global: [BandColor.RED, BandColor.LIGHT_RED, BandColor.YELLOW, BandColor.LIGHT_GREEN, BandColor.GREEN]
+      },
+      isInteger: true
     }
   },
   BP_HEART_ATTACK: {
@@ -1843,8 +1868,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: true
     }
   },
   IHB_COUNT: {
@@ -1870,7 +1896,8 @@ export const DFX_POINTS = {
       },
       dialBandColors: {
         global: []
-      }
+      },
+      isInteger: true
     }
   },
   MSI: {
@@ -1952,8 +1979,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: false
     }
   },
   BP_STROKE: {
@@ -2035,8 +2063,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: true
     }
   },
   BP_TAU: {
@@ -2118,8 +2147,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['RED', 'LIGHT_RED', 'YELLOW', 'LIGHT_GREEN', 'GREEN']
-      }
+        global: [BandColor.RED, BandColor.LIGHT_RED, BandColor.YELLOW, BandColor.LIGHT_GREEN, BandColor.GREEN]
+      },
+      isInteger: false
     }
   },
   HBA1C_RISK_PROB: {
@@ -2191,8 +2221,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: true
     }
   },
   MFBG_RISK_PROB: {
@@ -2264,8 +2295,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: true
     }
   },
   HPT_RISK_PROB: {
@@ -2337,8 +2369,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: true
     }
   },
   DBT_RISK_PROB: {
@@ -2410,8 +2443,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: true
     }
   },
   HDLTC_RISK_PROB: {
@@ -2483,8 +2517,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: true
     }
   },
   TG_RISK_PROB: {
@@ -2556,8 +2591,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: true
     }
   },
   AGE: {
@@ -2578,7 +2614,8 @@ export const DFX_POINTS = {
       },
       dialBandColors: {
         global: []
-      }
+      },
+      isInteger: true
     }
   },
   AGE_CVM: {
@@ -2599,7 +2636,8 @@ export const DFX_POINTS = {
       },
       dialBandColors: {
         global: []
-      }
+      },
+      isInteger: true
     }
   },
   FLD_RISK_PROB: {
@@ -2671,8 +2709,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: true
     }
   },
   HEIGHT: {
@@ -2693,7 +2732,8 @@ export const DFX_POINTS = {
       },
       dialBandColors: {
         global: []
-      }
+      },
+      isInteger: true
     }
   },
   MENTAL_SCORE: {
@@ -2722,7 +2762,8 @@ export const DFX_POINTS = {
       },
       dialBandColors: {
         global: []
-      }
+      },
+      isInteger: false
     }
   },
   OVERALL_METABOLIC_RISK_PROB: {
@@ -2794,8 +2835,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: true
     }
   },
   PHYSICAL_SCORE: {
@@ -2824,7 +2866,8 @@ export const DFX_POINTS = {
       },
       dialBandColors: {
         global: []
-      }
+      },
+      isInteger: false
     }
   },
   PHYSIO_SCORE: {
@@ -2853,7 +2896,8 @@ export const DFX_POINTS = {
       },
       dialBandColors: {
         global: []
-      }
+      },
+      isInteger: false
     }
   },
   RISKS_SCORE: {
@@ -2882,7 +2926,8 @@ export const DFX_POINTS = {
       },
       dialBandColors: {
         global: []
-      }
+      },
+      isInteger: false
     }
   },
   SURVEY_ANXIETY_MODERATE: {
@@ -2910,8 +2955,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: [ 'GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [ BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: false
     }
   },
   SURVEY_DEPRESSION_MODERATE: {
@@ -2939,8 +2985,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: [ 'GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [ BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: false
     }
   },
   VITAL_SCORE: {
@@ -2969,7 +3016,8 @@ export const DFX_POINTS = {
       },
       dialBandColors: {
         global: []
-      }
+      },
+      isInteger: false
     }
   },
   WAIST_CIRCUM: {
@@ -2990,7 +3038,8 @@ export const DFX_POINTS = {
       },
       dialBandColors: {
         global: []
-      }
+      },
+      isInteger: true
     }
   },
   WAIST_TO_HEIGHT: {
@@ -3324,12 +3373,13 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['YELLOW', 'GREEN', 'YELLOW', 'LIGHT_RED', 'RED'],
-        globalMale: ['YELLOW', 'GREEN', 'YELLOW', 'LIGHT_RED', 'RED'],
-        globalFemale: ['YELLOW', 'GREEN', 'YELLOW', 'LIGHT_RED', 'RED'],
-        eastAsiaMale: ['YELLOW', 'GREEN', 'YELLOW', 'LIGHT_RED', 'RED'],
-        eastAsiaFemale: ['YELLOW', 'GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [BandColor.YELLOW, BandColor.GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED],
+        globalMale: [BandColor.YELLOW, BandColor.GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED],
+        globalFemale: [BandColor.YELLOW, BandColor.GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED],
+        eastAsiaMale: [BandColor.YELLOW, BandColor.GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED],
+        eastAsiaFemale: [BandColor.YELLOW, BandColor.GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: false
     }
   },
   WEIGHT: {
@@ -3350,7 +3400,8 @@ export const DFX_POINTS = {
       },
       dialBandColors: {
         global: []
-      }
+      },
+      isInteger: true
     }
   }
 };
@@ -3392,7 +3443,8 @@ export const parseResults = (results) => {
             },
             dialBandColors: {
                 global: [],
-            }
+            },
+            isInteger: false,
         };
         const defaultInfo = {
             name: '',
@@ -3409,28 +3461,13 @@ export const parseResults = (results) => {
         let scalerValue = '0';
         let arrayValue = [];
         if (resultsType === RESULT_TYPE.SCALAR) {
-            scalerValue = (calculateMedian(Channels[point].Data) / Multiplier).toFixed(2);
+            const rawValue = calculateMedian(Channels[point].Data) / Multiplier;
+            scalerValue = pointMeta.isInteger ? Math.ceil(rawValue).toString() : rawValue.toFixed(2);
         } else {
-            arrayValue = Channels[point].Data.map(v => v / Multiplier);
+            arrayValue = pointMeta.isInteger
+                ? Channels[point].Data.map(v => Math.ceil(v / Multiplier))
+                : Channels[point].Data.map(v => Number((v / Multiplier).toFixed(2)));
         }
-        // if (['CVD_MULTI_YEAR_RISK_PROBS', 'CVD_MULTI_YEAR_RISK_YEARS'].includes(point)) {
-        //     if (point === 'CVD_MULTI_YEAR_RISK_YEARS') return; // Do not return CVD_MULTI_YEAR_RISK_YEARS point as a result
-        //     if (point === 'CVD_MULTI_YEAR_RISK_PROBS') {
-        //         const hasYears = 'CVD_MULTI_YEAR_RISK_YEARS' in Channels;
-        //         const hasProbs = 'CVD_MULTI_YEAR_RISK_PROBS' in Channels;
-        //         if (
-        //             hasYears && hasProbs &&
-        //             Channels['CVD_MULTI_YEAR_RISK_YEARS'].Data.length === Channels['CVD_MULTI_YEAR_RISK_PROBS'].Data.length
-        //         ) {
-        //             const years = Channels['CVD_MULTI_YEAR_RISK_YEARS'].Data.map(v => v / Multiplier);
-        //             const probs = Channels['CVD_MULTI_YEAR_RISK_PROBS'].Data.map(v => v / Multiplier);
-        //             const cvd = { years, probs };
-        //             console.log(`Processing point "${point}" with years:`, cvd);
-        //             // TODO: handle valid CVD multi-year risk data
-        //         }
-        //     }
-        //     return;
-        // }
 
         const range = ranges[population] ?? [];
         const bandColors = dialBandColors[population] ?? [];
@@ -3483,4 +3520,4 @@ export const parseResults = (results) => {
         }
     }
     return result;
-}
+};

--- a/react/client/hooks/useAutoStart.ts
+++ b/react/client/hooks/useAutoStart.ts
@@ -15,18 +15,21 @@ import { ErrorCodes } from '../types';
 export const useAutoStart = () => {
   const { config } = useSnapshot(state.config);
   const { isPermissionGranted, deviceId, isOpen } = useSnapshot(state.camera);
-  const { faceTrackerState } = useSnapshot(state.measurement);
+  const { faceTrackerState, isFaceTrackerLoaded } = useSnapshot(state.measurement);
   const canStartMeasurement = useCanStartMeasurement();
   const { isIdle } = useMeasurementPhase();
 
   /**
-   * Auto-start camera if cameraAutoStart is enabled
-   * Only runs when: config enabled, permission granted, device selected, camera not open
-   */
+  * Auto-start camera if cameraAutoStart is enabled.
+   * Gated on isFaceTrackerLoaded so the camera stream isn't acquired until the
+   * SDK is ready to consume it via setMediaStream. Otherwise the stream sits
+   * idle while tracker assets download, and mobile browsers can suspend an
+   * unattached stream — leaving us with a frozen video feed and no mask.
+  */
   useEffect(() => {
     if (!config.cameraAutoStart || !isIdle) return;
 
-    if (isPermissionGranted && deviceId && !isOpen) {
+    if (isPermissionGranted && deviceId && !isOpen && isFaceTrackerLoaded) {
       // Simply start the camera with the already-selected deviceId
       (async () => {
         const success = await state.camera.start(CAMERA_WIDTH, CAMERA_HEIGHT);
@@ -39,7 +42,7 @@ export const useAutoStart = () => {
         }
       })();
     }
-  }, [config.cameraAutoStart, isPermissionGranted, deviceId, isOpen, isIdle]);
+  }, [config.cameraAutoStart, isPermissionGranted, deviceId, isOpen, isIdle, isFaceTrackerLoaded]);
 
   /**
    * Auto-start measurement if measurementAutoStart is enabled

--- a/react/client/pages/Results/MetricCard.tsx
+++ b/react/client/pages/Results/MetricCard.tsx
@@ -1,3 +1,4 @@
+import React, { useState } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import { useSnapshot } from 'valtio';
 import type { DfxPointId, Point, Results } from './helpers';
@@ -58,6 +59,24 @@ const styles = stylex.create({
   valueDark: {
     color: '#f8fafc',
   },
+  slider: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 8,
+    marginTop: 4,
+  },
+  sliderInput: {
+    flex: 1,
+    height: 4,
+    cursor: 'pointer',
+    accentColor: '#000000',
+  },
+  sliderLabel: {
+    fontSize: 12,
+    fontWeight: 600,
+    minWidth: 24,
+    textAlign: 'center' as const,
+  },
 });
 
 const MetricCard = ({ point, dfxPointId, results }: { dfxPointId: DfxPointId; point: Point; results: Results }) => {
@@ -70,13 +89,15 @@ const MetricCard = ({ point, dfxPointId, results }: { dfxPointId: DfxPointId; po
   // Handle CVD_MULTI_YEAR_RISK_PROBS: extract the probability for a specific year
   let displayValue: string | number[] = value;
   // targetYear: value between 1 and 20 representing the year horizon for CVD risk
-  const targetYear = 10;
+  const [targetYear, setTargetYear] = useState(10);
   let isCvdRisk = false;
   if (dfxPointId === 'CVD_MULTI_YEAR_RISK_PROBS' && Array.isArray(value)) {
     const yearsPoint = results.points['CVD_MULTI_YEAR_RISK_YEARS'];
     if (yearsPoint && Array.isArray(yearsPoint.value)) {
       const index = yearsPoint.value.indexOf(targetYear);
-      displayValue = index !== -1 ? (value[index]?.toFixed(2) ?? 'N/A') : 'N/A';
+      displayValue = index !== -1 && value[index] != null
+        ? String(value[index])
+        : 'N/A';
       isCvdRisk = true;
     }
   }
@@ -126,7 +147,22 @@ const MetricCard = ({ point, dfxPointId, results }: { dfxPointId: DfxPointId; po
         {info.unit && <Paragraph>{info.unit}</Paragraph>}
       </div>
       {isCvdRisk && (
-        <Paragraph>{`${targetYear}-year risk`}</Paragraph>
+        <>
+          <Paragraph>{`${targetYear}-year risk`}</Paragraph>
+          <div {...stylex.props(styles.slider)}>
+            <span {...stylex.props(styles.sliderLabel, isDark ? styles.valueDark : styles.valueLight)}>1</span>
+            <input
+              {...stylex.props(styles.sliderInput)}
+              type="range"
+              min={1}
+              max={20}
+              value={targetYear}
+              onChange={(e) => setTargetYear(Number(e.target.value))}
+              onClick={(e) => e.stopPropagation()}
+            />
+            <span {...stylex.props(styles.sliderLabel, isDark ? styles.valueDark : styles.valueLight)}>20</span>
+          </div>
+        </>
       )}
     </div>
   );

--- a/react/client/pages/Results/helpers.ts
+++ b/react/client/pages/Results/helpers.ts
@@ -6,20 +6,6 @@ import type {
     RealtimeResultErrors
 } from '@nuralogix.ai/anura-web-core-sdk';
 
-/**
- * "metadata" |
- * "physical" |
- * "generalRisks" |
- * "vitals" |
- * "physiological" |
- * "metabolicRisks" |
- * "bloodBiomarkers" |
- * "overall" |
- * "mental" |
- * "surveys" 
- */
-export type PointGroupType = typeof pointGroup[keyof typeof pointGroup];
-
 export type RangePopulation = {
   [K in DfxPointId]: keyof typeof DFX_POINTS[K]["meta"]["ranges"];
 }[DfxPointId];
@@ -37,13 +23,38 @@ export interface DfxPoints {
 export interface IPointName {
     name: string;
     unit: string;
-}
+};
 
 export interface ILocalization {
     [x: string] : IPointName;
 };
 
-export type BandColors = ('YELLOW' | 'LIGHT_GREEN' | 'GREEN' | 'LIGHT_RED' | 'RED')[];
+export const BandColor = {
+    YELLOW: 'YELLOW',
+    LIGHT_GREEN: 'LIGHT_GREEN',
+    GREEN: 'GREEN',
+    LIGHT_RED: 'LIGHT_RED',
+    RED: 'RED',
+} as const;
+
+export type BandColor = typeof BandColor[keyof typeof BandColor];
+
+export type BandColors = BandColor[];
+
+export const pointGroup = {
+    METADATA: 'metadata',
+    PHYSICAL: 'physical',
+    GENERAL_RISKS: 'generalRisks',
+    VITALS: 'vitals',
+    PHYSIOLOGICAL: 'physiological',
+    METABOLIC_RISKS: 'metabolicRisks',
+    BLOOD_BIOMARKERS: 'bloodBiomarkers',
+    OVERALL: 'overall',
+    MENTAL: 'mental',
+    SURVEYS: 'surveys',
+} as const;
+
+export type PointGroupType = typeof pointGroup[keyof typeof pointGroup];
 
 export interface DFXMeta {
     resultsType: keyof typeof RESULT_TYPE;
@@ -62,14 +73,15 @@ export interface DFXMeta {
     },
     dialBandColors: {
         readonly [x: string]: Readonly<BandColors> | BandColors;
-    }
+    },
+    isInteger: boolean;
 };
 
 export interface DialSection {
     groupSize: number;
-    bandColor: 'YELLOW' | 'LIGHT_GREEN' | 'GREEN' | 'LIGHT_RED' | 'RED';
+    bandColor: BandColor;
     range: number[];
-}
+};
 
 export interface Point {
     channel: string;
@@ -85,7 +97,7 @@ export interface Point {
         name: string;
         unit: string;
     }
-}
+};
 
 export type Points = {
     [x in DfxPointId]?: Point;
@@ -98,7 +110,7 @@ interface ResultsError {
             messages: string[];
         };
     };
-}
+};
 
 export interface Results {
     measurementId: string;
@@ -106,7 +118,7 @@ export interface Results {
     points: Points;
     errors: ResultsError;
     statusId: string;
-}
+};
 
 const en: ILocalization  = {
   ABSI: {
@@ -287,26 +299,13 @@ export const localication = {
     en,
 };
 
-export const pointGroup = {
-    METADATA: 'metadata',
-    PHYSICAL: 'physical',
-    GENERAL_RISKS: 'generalRisks',
-    VITALS: 'vitals',
-    PHYSIOLOGICAL: 'physiological',
-    METABOLIC_RISKS: 'metabolicRisks',
-    BLOOD_BIOMARKERS: 'bloodBiomarkers',
-    OVERALL: 'overall',
-    MENTAL: 'mental',
-    SURVEYS: 'surveys',
-};
-
 export const RESULT_TYPE = {
     SCALAR: 'SCALAR',
     ARRAY: 'ARRAY',
     INTERNAL: 'INTERNAL'
 } as const;
 
-export const DFX_POINTS = {
+export const DFX_POINTS: DfxPoints = {
   VITALITY: {
     meta: {
       resultsType: RESULT_TYPE.SCALAR,
@@ -386,8 +385,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['RED', 'LIGHT_RED', 'YELLOW', 'LIGHT_GREEN', 'GREEN']
-      }
+        global: [BandColor.RED, BandColor.LIGHT_RED, BandColor.YELLOW, BandColor.LIGHT_GREEN, BandColor.GREEN]
+      },
+      isInteger: false
     }
   },
   SMK_RISK_PROB: {
@@ -459,8 +459,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: true
     }
   },
   SLEEP_QUALITY: {
@@ -542,8 +543,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['RED', 'LIGHT_RED', 'YELLOW', 'LIGHT_GREEN', 'GREEN']
-      }
+        global: [BandColor.RED, BandColor.LIGHT_RED, BandColor.YELLOW, BandColor.LIGHT_GREEN, BandColor.GREEN]
+      },
+      isInteger: false
     }
   },
   ANXIETY_INDEX: {
@@ -625,8 +627,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: false
     }
   },
   SNR: {
@@ -647,7 +650,8 @@ export const DFX_POINTS = {
       },
       dialBandColors: {
         global: []
-      }
+      },
+      isInteger: false
     }
   },
   HR_BPM: {
@@ -725,8 +729,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['YELLOW', 'GREEN', 'YELLOW']
-      }
+        global: [BandColor.YELLOW, BandColor.GREEN, BandColor.YELLOW]
+      },
+      isInteger: true
     }
   },
   BP_SYSTOLIC: {
@@ -808,8 +813,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['YELLOW', 'GREEN', 'LIGHT_GREEN', 'YELLOW', 'RED']
-      }
+        global: [BandColor.YELLOW, BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.RED]
+      },
+      isInteger: true
     }
   },
   BP_DIASTOLIC: {
@@ -891,8 +897,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['YELLOW', 'GREEN', 'LIGHT_GREEN', 'YELLOW', 'RED']
-      }
+        global: [BandColor.YELLOW, BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.RED]
+      },
+      isInteger: true
     }
   },
   BR_BPM: {
@@ -970,8 +977,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['YELLOW', 'GREEN', 'YELLOW']
-      }
+        global: [BandColor.YELLOW, BandColor.GREEN, BandColor.YELLOW]
+      },
+      isInteger: true
     }
   },
   HRV_SDNN: {
@@ -1053,8 +1061,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['RED', 'LIGHT_RED', 'YELLOW', 'LIGHT_GREEN', 'GREEN']
-      }
+        global: [BandColor.RED, BandColor.LIGHT_RED, BandColor.YELLOW, BandColor.LIGHT_GREEN, BandColor.GREEN]
+      },
+      isInteger: true
     }
   },
   ABSI: {
@@ -1325,11 +1334,12 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        globalMale: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED'],
-        globalFemale: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED'],
-        eastAsiaMale: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED'],
-        eastAsiaFemale: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        globalMale: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED],
+        globalFemale: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED],
+        eastAsiaMale: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED],
+        eastAsiaFemale: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: false
     }
   },
   BMI_CALC: {
@@ -1513,10 +1523,11 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: [ 'YELLOW', 'GREEN', 'YELLOW', 'LIGHT_RED', 'RED' ],
-        eastAsiaMale: [ 'YELLOW', 'GREEN', 'YELLOW', 'RED' ],
-        eastAsiaFemale: [ 'YELLOW', 'GREEN', 'YELLOW', 'RED' ]
-      }
+        global: [ BandColor.YELLOW, BandColor.GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED ],
+        eastAsiaMale: [ BandColor.YELLOW, BandColor.GREEN, BandColor.YELLOW, BandColor.RED ],
+        eastAsiaFemale: [ BandColor.YELLOW, BandColor.GREEN, BandColor.YELLOW, BandColor.RED ]
+      },
+      isInteger: true
     }
   },
   BP_RPP: {
@@ -1598,8 +1609,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: false
     }
   },
   BP_CVD: {
@@ -1681,8 +1693,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: true
     }
   },
   CVD_MULTI_YEAR_RISK_YEARS: {
@@ -1703,7 +1716,8 @@ export const DFX_POINTS = {
       },
       dialBandColors: {
         global: []
-      }
+      },
+      isInteger: false
     }
   },
   CVD_MULTI_YEAR_RISK_PROBS: {
@@ -1785,8 +1799,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: true
     }
   },
   HEALTH_SCORE: {
@@ -1868,8 +1883,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['RED', 'LIGHT_RED', 'YELLOW', 'LIGHT_GREEN', 'GREEN']
-      }
+        global: [BandColor.RED, BandColor.LIGHT_RED, BandColor.YELLOW, BandColor.LIGHT_GREEN, BandColor.GREEN]
+      },
+      isInteger: true
     }
   },
   BP_HEART_ATTACK: {
@@ -1951,8 +1967,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: true
     }
   },
   IHB_COUNT: {
@@ -1978,7 +1995,8 @@ export const DFX_POINTS = {
       },
       dialBandColors: {
         global: []
-      }
+      },
+      isInteger: true
     }
   },
   MSI: {
@@ -2060,8 +2078,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: false
     }
   },
   BP_STROKE: {
@@ -2143,8 +2162,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: true
     }
   },
   BP_TAU: {
@@ -2226,8 +2246,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['RED', 'LIGHT_RED', 'YELLOW', 'LIGHT_GREEN', 'GREEN']
-      }
+        global: [BandColor.RED, BandColor.LIGHT_RED, BandColor.YELLOW, BandColor.LIGHT_GREEN, BandColor.GREEN]
+      },
+      isInteger: false
     }
   },
   HBA1C_RISK_PROB: {
@@ -2299,8 +2320,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: true
     }
   },
   MFBG_RISK_PROB: {
@@ -2372,8 +2394,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: true
     }
   },
   HPT_RISK_PROB: {
@@ -2445,8 +2468,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: true
     }
   },
   DBT_RISK_PROB: {
@@ -2518,8 +2542,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: true
     }
   },
   HDLTC_RISK_PROB: {
@@ -2591,8 +2616,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: true
     }
   },
   TG_RISK_PROB: {
@@ -2664,8 +2690,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: true
     }
   },
   AGE: {
@@ -2686,7 +2713,8 @@ export const DFX_POINTS = {
       },
       dialBandColors: {
         global: []
-      }
+      },
+      isInteger: true
     }
   },
   AGE_CVM: {
@@ -2707,7 +2735,8 @@ export const DFX_POINTS = {
       },
       dialBandColors: {
         global: []
-      }
+      },
+      isInteger: true
     }
   },
   FLD_RISK_PROB: {
@@ -2779,8 +2808,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: true
     }
   },
   HEIGHT: {
@@ -2801,7 +2831,8 @@ export const DFX_POINTS = {
       },
       dialBandColors: {
         global: []
-      }
+      },
+      isInteger: true
     }
   },
   MENTAL_SCORE: {
@@ -2830,7 +2861,8 @@ export const DFX_POINTS = {
       },
       dialBandColors: {
         global: []
-      }
+      },
+      isInteger: false
     }
   },
   OVERALL_METABOLIC_RISK_PROB: {
@@ -2902,8 +2934,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: true
     }
   },
   PHYSICAL_SCORE: {
@@ -2932,7 +2965,8 @@ export const DFX_POINTS = {
       },
       dialBandColors: {
         global: []
-      }
+      },
+      isInteger: false
     }
   },
   PHYSIO_SCORE: {
@@ -2961,7 +2995,8 @@ export const DFX_POINTS = {
       },
       dialBandColors: {
         global: []
-      }
+      },
+      isInteger: false
     }
   },
   RISKS_SCORE: {
@@ -2990,7 +3025,8 @@ export const DFX_POINTS = {
       },
       dialBandColors: {
         global: []
-      }
+      },
+      isInteger: false
     }
   },
   SURVEY_ANXIETY_MODERATE: {
@@ -3018,8 +3054,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: [ 'GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [ BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: false
     }
   },
   SURVEY_DEPRESSION_MODERATE: {
@@ -3047,8 +3084,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: [ 'GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [ BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: false
     }
   },
   VITAL_SCORE: {
@@ -3077,7 +3115,8 @@ export const DFX_POINTS = {
       },
       dialBandColors: {
         global: []
-      }
+      },
+      isInteger: false
     }
   },
   WAIST_CIRCUM: {
@@ -3098,7 +3137,8 @@ export const DFX_POINTS = {
       },
       dialBandColors: {
         global: []
-      }
+      },
+      isInteger: true
     }
   },
   WAIST_TO_HEIGHT: {
@@ -3432,12 +3472,13 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['YELLOW', 'GREEN', 'YELLOW', 'LIGHT_RED', 'RED'],
-        globalMale: ['YELLOW', 'GREEN', 'YELLOW', 'LIGHT_RED', 'RED'],
-        globalFemale: ['YELLOW', 'GREEN', 'YELLOW', 'LIGHT_RED', 'RED'],
-        eastAsiaMale: ['YELLOW', 'GREEN', 'YELLOW', 'LIGHT_RED', 'RED'],
-        eastAsiaFemale: ['YELLOW', 'GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [BandColor.YELLOW, BandColor.GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED],
+        globalMale: [BandColor.YELLOW, BandColor.GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED],
+        globalFemale: [BandColor.YELLOW, BandColor.GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED],
+        eastAsiaMale: [BandColor.YELLOW, BandColor.GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED],
+        eastAsiaFemale: [BandColor.YELLOW, BandColor.GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: false
     }
   },
   WEIGHT: {
@@ -3458,7 +3499,8 @@ export const DFX_POINTS = {
       },
       dialBandColors: {
         global: []
-      }
+      },
+      isInteger: true
     }
   }
 } as const;
@@ -3506,7 +3548,8 @@ export const parseResults = (results: DFXResults): Results => {
             },
             dialBandColors: {
                 global: [],
-            }
+            },
+            isInteger: false,
         };
         const defaultInfo = {
             name: '',
@@ -3525,9 +3568,12 @@ export const parseResults = (results: DFXResults): Results => {
         let scalerValue = '0';
         let arrayValue: number[] = [];
         if (resultsType === RESULT_TYPE.SCALAR) {
-            scalerValue = (calculateMedian(Channels[point].Data) / Multiplier).toFixed(2);
+            const rawValue = calculateMedian(Channels[point].Data) / Multiplier;
+            scalerValue = pointMeta.isInteger ? Math.ceil(rawValue).toString() : rawValue.toFixed(2);
         } else {
-            arrayValue = Channels[point].Data.map(v => v / Multiplier);
+            arrayValue = pointMeta.isInteger
+                ? Channels[point].Data.map(v => Math.ceil(v / Multiplier))
+                : Channels[point].Data.map(v => Number((v / Multiplier).toFixed(2)));
         }
 
         const range = ranges[population] ?? [];
@@ -3581,4 +3627,4 @@ export const parseResults = (results: DFXResults): Results => {
         }
     }
     return result;
-}
+};

--- a/typescript/src/helpers.ts
+++ b/typescript/src/helpers.ts
@@ -4,21 +4,7 @@ import type {
     DFXResults,
     RealtimeResultNotes,
     RealtimeResultErrors
-} from "@nuralogix.ai/anura-web-core-sdk";
-
-/**
- * "metadata" |
- * "physical" |
- * "generalRisks" |
- * "vitals" |
- * "physiological" |
- * "metabolicRisks" |
- * "bloodBiomarkers" |
- * "overall" |
- * "mental" |
- * "surveys" 
- */
-export type PointGroupType = typeof pointGroup[keyof typeof pointGroup];
+} from '@nuralogix.ai/anura-web-core-sdk';
 
 export type RangePopulation = {
   [K in DfxPointId]: keyof typeof DFX_POINTS[K]["meta"]["ranges"];
@@ -37,13 +23,38 @@ export interface DfxPoints {
 export interface IPointName {
     name: string;
     unit: string;
-}
+};
 
 export interface ILocalization {
     [x: string] : IPointName;
 };
 
-export type BandColors = ('YELLOW' | 'LIGHT_GREEN' | 'GREEN' | 'LIGHT_RED' | 'RED')[];
+export const BandColor = {
+    YELLOW: 'YELLOW',
+    LIGHT_GREEN: 'LIGHT_GREEN',
+    GREEN: 'GREEN',
+    LIGHT_RED: 'LIGHT_RED',
+    RED: 'RED',
+} as const;
+
+export type BandColor = typeof BandColor[keyof typeof BandColor];
+
+export type BandColors = BandColor[];
+
+export const pointGroup = {
+    METADATA: 'metadata',
+    PHYSICAL: 'physical',
+    GENERAL_RISKS: 'generalRisks',
+    VITALS: 'vitals',
+    PHYSIOLOGICAL: 'physiological',
+    METABOLIC_RISKS: 'metabolicRisks',
+    BLOOD_BIOMARKERS: 'bloodBiomarkers',
+    OVERALL: 'overall',
+    MENTAL: 'mental',
+    SURVEYS: 'surveys',
+} as const;
+
+export type PointGroupType = typeof pointGroup[keyof typeof pointGroup];
 
 export interface DFXMeta {
     resultsType: keyof typeof RESULT_TYPE;
@@ -62,14 +73,15 @@ export interface DFXMeta {
     },
     dialBandColors: {
         readonly [x: string]: Readonly<BandColors> | BandColors;
-    }
+    },
+    isInteger: boolean;
 };
 
 export interface DialSection {
     groupSize: number;
-    bandColor: 'YELLOW' | 'LIGHT_GREEN' | 'GREEN' | 'LIGHT_RED' | 'RED';
+    bandColor: BandColor;
     range: number[];
-}
+};
 
 export interface Point {
     channel: string;
@@ -85,7 +97,7 @@ export interface Point {
         name: string;
         unit: string;
     }
-}
+};
 
 export type Points = {
     [x in DfxPointId]?: Point;
@@ -98,7 +110,7 @@ interface ResultsError {
             messages: string[];
         };
     };
-}
+};
 
 export interface Results {
     measurementId: string;
@@ -106,7 +118,7 @@ export interface Results {
     points: Points;
     errors: ResultsError;
     statusId: string;
-}
+};
 
 const en: ILocalization  = {
   ABSI: {
@@ -287,26 +299,13 @@ export const localication = {
     en,
 };
 
-export const pointGroup = {
-    METADATA: 'metadata',
-    PHYSICAL: 'physical',
-    GENERAL_RISKS: 'generalRisks',
-    VITALS: 'vitals',
-    PHYSIOLOGICAL: 'physiological',
-    METABOLIC_RISKS: 'metabolicRisks',
-    BLOOD_BIOMARKERS: 'bloodBiomarkers',
-    OVERALL: 'overall',
-    MENTAL: 'mental',
-    SURVEYS: 'surveys',
-};
-
 export const RESULT_TYPE = {
     SCALAR: 'SCALAR',
     ARRAY: 'ARRAY',
     INTERNAL: 'INTERNAL'
 } as const;
 
-export const DFX_POINTS = {
+export const DFX_POINTS: DfxPoints = {
   VITALITY: {
     meta: {
       resultsType: RESULT_TYPE.SCALAR,
@@ -386,8 +385,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['RED', 'LIGHT_RED', 'YELLOW', 'LIGHT_GREEN', 'GREEN']
-      }
+        global: [BandColor.RED, BandColor.LIGHT_RED, BandColor.YELLOW, BandColor.LIGHT_GREEN, BandColor.GREEN]
+      },
+      isInteger: false
     }
   },
   SMK_RISK_PROB: {
@@ -459,8 +459,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: true
     }
   },
   SLEEP_QUALITY: {
@@ -542,8 +543,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['RED', 'LIGHT_RED', 'YELLOW', 'LIGHT_GREEN', 'GREEN']
-      }
+        global: [BandColor.RED, BandColor.LIGHT_RED, BandColor.YELLOW, BandColor.LIGHT_GREEN, BandColor.GREEN]
+      },
+      isInteger: false
     }
   },
   ANXIETY_INDEX: {
@@ -625,8 +627,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: false
     }
   },
   SNR: {
@@ -647,7 +650,8 @@ export const DFX_POINTS = {
       },
       dialBandColors: {
         global: []
-      }
+      },
+      isInteger: false
     }
   },
   HR_BPM: {
@@ -725,8 +729,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['YELLOW', 'GREEN', 'YELLOW']
-      }
+        global: [BandColor.YELLOW, BandColor.GREEN, BandColor.YELLOW]
+      },
+      isInteger: true
     }
   },
   BP_SYSTOLIC: {
@@ -808,8 +813,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['YELLOW', 'GREEN', 'LIGHT_GREEN', 'YELLOW', 'RED']
-      }
+        global: [BandColor.YELLOW, BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.RED]
+      },
+      isInteger: true
     }
   },
   BP_DIASTOLIC: {
@@ -891,8 +897,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['YELLOW', 'GREEN', 'LIGHT_GREEN', 'YELLOW', 'RED']
-      }
+        global: [BandColor.YELLOW, BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.RED]
+      },
+      isInteger: true
     }
   },
   BR_BPM: {
@@ -970,8 +977,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['YELLOW', 'GREEN', 'YELLOW']
-      }
+        global: [BandColor.YELLOW, BandColor.GREEN, BandColor.YELLOW]
+      },
+      isInteger: true
     }
   },
   HRV_SDNN: {
@@ -1053,8 +1061,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['RED', 'LIGHT_RED', 'YELLOW', 'LIGHT_GREEN', 'GREEN']
-      }
+        global: [BandColor.RED, BandColor.LIGHT_RED, BandColor.YELLOW, BandColor.LIGHT_GREEN, BandColor.GREEN]
+      },
+      isInteger: true
     }
   },
   ABSI: {
@@ -1325,11 +1334,12 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        globalMale: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED'],
-        globalFemale: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED'],
-        eastAsiaMale: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED'],
-        eastAsiaFemale: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        globalMale: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED],
+        globalFemale: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED],
+        eastAsiaMale: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED],
+        eastAsiaFemale: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: false
     }
   },
   BMI_CALC: {
@@ -1513,10 +1523,11 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: [ 'YELLOW', 'GREEN', 'YELLOW', 'LIGHT_RED', 'RED' ],
-        eastAsiaMale: [ 'YELLOW', 'GREEN', 'YELLOW', 'RED' ],
-        eastAsiaFemale: [ 'YELLOW', 'GREEN', 'YELLOW', 'RED' ]
-      }
+        global: [ BandColor.YELLOW, BandColor.GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED ],
+        eastAsiaMale: [ BandColor.YELLOW, BandColor.GREEN, BandColor.YELLOW, BandColor.RED ],
+        eastAsiaFemale: [ BandColor.YELLOW, BandColor.GREEN, BandColor.YELLOW, BandColor.RED ]
+      },
+      isInteger: true
     }
   },
   BP_RPP: {
@@ -1598,8 +1609,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: false
     }
   },
   BP_CVD: {
@@ -1681,8 +1693,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: true
     }
   },
   CVD_MULTI_YEAR_RISK_YEARS: {
@@ -1703,7 +1716,8 @@ export const DFX_POINTS = {
       },
       dialBandColors: {
         global: []
-      }
+      },
+      isInteger: false
     }
   },
   CVD_MULTI_YEAR_RISK_PROBS: {
@@ -1785,8 +1799,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: true
     }
   },
   HEALTH_SCORE: {
@@ -1868,8 +1883,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['RED', 'LIGHT_RED', 'YELLOW', 'LIGHT_GREEN', 'GREEN']
-      }
+        global: [BandColor.RED, BandColor.LIGHT_RED, BandColor.YELLOW, BandColor.LIGHT_GREEN, BandColor.GREEN]
+      },
+      isInteger: true
     }
   },
   BP_HEART_ATTACK: {
@@ -1951,8 +1967,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: true
     }
   },
   IHB_COUNT: {
@@ -1978,7 +1995,8 @@ export const DFX_POINTS = {
       },
       dialBandColors: {
         global: []
-      }
+      },
+      isInteger: true
     }
   },
   MSI: {
@@ -2060,8 +2078,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: false
     }
   },
   BP_STROKE: {
@@ -2143,8 +2162,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: true
     }
   },
   BP_TAU: {
@@ -2226,8 +2246,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['RED', 'LIGHT_RED', 'YELLOW', 'LIGHT_GREEN', 'GREEN']
-      }
+        global: [BandColor.RED, BandColor.LIGHT_RED, BandColor.YELLOW, BandColor.LIGHT_GREEN, BandColor.GREEN]
+      },
+      isInteger: false
     }
   },
   HBA1C_RISK_PROB: {
@@ -2299,8 +2320,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: true
     }
   },
   MFBG_RISK_PROB: {
@@ -2372,8 +2394,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: true
     }
   },
   HPT_RISK_PROB: {
@@ -2445,8 +2468,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: true
     }
   },
   DBT_RISK_PROB: {
@@ -2518,8 +2542,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: true
     }
   },
   HDLTC_RISK_PROB: {
@@ -2591,8 +2616,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: true
     }
   },
   TG_RISK_PROB: {
@@ -2664,8 +2690,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: true
     }
   },
   AGE: {
@@ -2686,7 +2713,8 @@ export const DFX_POINTS = {
       },
       dialBandColors: {
         global: []
-      }
+      },
+      isInteger: true
     }
   },
   AGE_CVM: {
@@ -2707,7 +2735,8 @@ export const DFX_POINTS = {
       },
       dialBandColors: {
         global: []
-      }
+      },
+      isInteger: true
     }
   },
   FLD_RISK_PROB: {
@@ -2779,8 +2808,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: true
     }
   },
   HEIGHT: {
@@ -2801,7 +2831,8 @@ export const DFX_POINTS = {
       },
       dialBandColors: {
         global: []
-      }
+      },
+      isInteger: true
     }
   },
   MENTAL_SCORE: {
@@ -2830,7 +2861,8 @@ export const DFX_POINTS = {
       },
       dialBandColors: {
         global: []
-      }
+      },
+      isInteger: false
     }
   },
   OVERALL_METABOLIC_RISK_PROB: {
@@ -2902,8 +2934,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: true
     }
   },
   PHYSICAL_SCORE: {
@@ -2932,7 +2965,8 @@ export const DFX_POINTS = {
       },
       dialBandColors: {
         global: []
-      }
+      },
+      isInteger: false
     }
   },
   PHYSIO_SCORE: {
@@ -2961,7 +2995,8 @@ export const DFX_POINTS = {
       },
       dialBandColors: {
         global: []
-      }
+      },
+      isInteger: false
     }
   },
   RISKS_SCORE: {
@@ -2990,7 +3025,8 @@ export const DFX_POINTS = {
       },
       dialBandColors: {
         global: []
-      }
+      },
+      isInteger: false
     }
   },
   SURVEY_ANXIETY_MODERATE: {
@@ -3018,8 +3054,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: [ 'GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [ BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: false
     }
   },
   SURVEY_DEPRESSION_MODERATE: {
@@ -3047,8 +3084,9 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: [ 'GREEN', 'LIGHT_GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [ BandColor.GREEN, BandColor.LIGHT_GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: false
     }
   },
   VITAL_SCORE: {
@@ -3077,7 +3115,8 @@ export const DFX_POINTS = {
       },
       dialBandColors: {
         global: []
-      }
+      },
+      isInteger: false
     }
   },
   WAIST_CIRCUM: {
@@ -3098,7 +3137,8 @@ export const DFX_POINTS = {
       },
       dialBandColors: {
         global: []
-      }
+      },
+      isInteger: true
     }
   },
   WAIST_TO_HEIGHT: {
@@ -3432,12 +3472,13 @@ export const DFX_POINTS = {
         ]
       },
       dialBandColors: {
-        global: ['YELLOW', 'GREEN', 'YELLOW', 'LIGHT_RED', 'RED'],
-        globalMale: ['YELLOW', 'GREEN', 'YELLOW', 'LIGHT_RED', 'RED'],
-        globalFemale: ['YELLOW', 'GREEN', 'YELLOW', 'LIGHT_RED', 'RED'],
-        eastAsiaMale: ['YELLOW', 'GREEN', 'YELLOW', 'LIGHT_RED', 'RED'],
-        eastAsiaFemale: ['YELLOW', 'GREEN', 'YELLOW', 'LIGHT_RED', 'RED']
-      }
+        global: [BandColor.YELLOW, BandColor.GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED],
+        globalMale: [BandColor.YELLOW, BandColor.GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED],
+        globalFemale: [BandColor.YELLOW, BandColor.GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED],
+        eastAsiaMale: [BandColor.YELLOW, BandColor.GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED],
+        eastAsiaFemale: [BandColor.YELLOW, BandColor.GREEN, BandColor.YELLOW, BandColor.LIGHT_RED, BandColor.RED]
+      },
+      isInteger: false
     }
   },
   WEIGHT: {
@@ -3458,7 +3499,8 @@ export const DFX_POINTS = {
       },
       dialBandColors: {
         global: []
-      }
+      },
+      isInteger: true
     }
   }
 } as const;
@@ -3506,7 +3548,8 @@ export const parseResults = (results: DFXResults): Results => {
             },
             dialBandColors: {
                 global: [],
-            }
+            },
+            isInteger: false,
         };
         const defaultInfo = {
             name: '',
@@ -3525,9 +3568,12 @@ export const parseResults = (results: DFXResults): Results => {
         let scalerValue = '0';
         let arrayValue: number[] = [];
         if (resultsType === RESULT_TYPE.SCALAR) {
-            scalerValue = (calculateMedian(Channels[point].Data) / Multiplier).toFixed(2);
+            const rawValue = calculateMedian(Channels[point].Data) / Multiplier;
+            scalerValue = pointMeta.isInteger ? Math.ceil(rawValue).toString() : rawValue.toFixed(2);
         } else {
-            arrayValue = Channels[point].Data.map(v => v / Multiplier);
+            arrayValue = pointMeta.isInteger
+                ? Channels[point].Data.map(v => Math.ceil(v / Multiplier))
+                : Channels[point].Data.map(v => Number((v / Multiplier).toFixed(2)));
         }
 
         const range = ranges[population] ?? [];
@@ -3581,4 +3627,4 @@ export const parseResults = (results: DFXResults): Results => {
         }
     }
     return result;
-}
+};


### PR DESCRIPTION
- Introduced a slider component in MetricCard to allow users to select the target year for CVD risk.
- Updated state management to handle the selected target year.
- Refactored type definitions in helpers.ts to improve clarity and maintainability.
- Replaced string literals for band colors with a BandColor enum for better type safety.
- Ensured that the isInteger property is consistently applied across DFX_POINTS for accurate data representation.